### PR TITLE
Fix: find date with name fixed

### DIFF
--- a/src/main/java/dh/scheduler/controller/ScheduleController.java
+++ b/src/main/java/dh/scheduler/controller/ScheduleController.java
@@ -30,7 +30,6 @@ public class ScheduleController {
         return new ResponseEntity<>(scheduleService.saveSchedule(requestDto), HttpStatus.CREATED);
     }
 
-
     /**
      * 선택 일정 조회 API
      * @param id 선택한 id 식별자

--- a/src/main/java/dh/scheduler/repository/JdbcTemplateScheduleRepository.java
+++ b/src/main/java/dh/scheduler/repository/JdbcTemplateScheduleRepository.java
@@ -63,9 +63,25 @@ public class JdbcTemplateScheduleRepository implements ScheduleRepository {
     }
 
     @Override
-    public List<ScheduleResponseDto> findListSchedules(String date, String name) {
-        return jdbcTemplate.query("select * from Schedule where user_name = ? or date(update_date) = ?", scheduleRowMappers(), name, date);
+    public List<ScheduleResponseDto> findScheduleListByDate(String date) {
+        return jdbcTemplate.query("select * from Schedule where date(update_date) = ?", scheduleRowMappers(), date);
     }
+
+    @Override
+    public List<ScheduleResponseDto> findScheduleListByName(String name) {
+        return jdbcTemplate.query("select * from Schedule where user_name = ?", scheduleRowMappers(), name);
+    }
+
+    @Override
+    public List<ScheduleResponseDto> findScheduleListByNameWithDate(String date, String name) {
+        return jdbcTemplate.query("select * from Schedule where user_name = ? and date(update_date) = ?", scheduleRowMappers(), name, date);
+    }
+
+    @Override
+    public List<ScheduleResponseDto> findAllScheduleLists() {
+        return jdbcTemplate.query("select * from Schedule", scheduleRowMappers());
+    }
+
 
     private RowMapper<Schedule> scheduleRowMapper() {
         return new RowMapper<Schedule>() {

--- a/src/main/java/dh/scheduler/repository/ScheduleRepository.java
+++ b/src/main/java/dh/scheduler/repository/ScheduleRepository.java
@@ -12,5 +12,12 @@ public interface ScheduleRepository {
 
     Schedule findScheduleById(Long id);
 
-    List<ScheduleResponseDto> findListSchedules(String date, String name);
+    List<ScheduleResponseDto> findScheduleListByDate(String date);
+
+    List<ScheduleResponseDto> findScheduleListByName(String name);
+
+    List<ScheduleResponseDto> findScheduleListByNameWithDate(String date, String name);
+
+    List<ScheduleResponseDto> findAllScheduleLists();
+
 }

--- a/src/main/java/dh/scheduler/service/ScheduleServiceImpl.java
+++ b/src/main/java/dh/scheduler/service/ScheduleServiceImpl.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -43,6 +44,24 @@ public class ScheduleServiceImpl implements ScheduleService{
     @Override
     public List<ScheduleResponseDto> findListSchedules(String date, String name) {
 
-        return scheduleRepository.findListSchedules(date, name);
+        List<ScheduleResponseDto> findList = new ArrayList<>();
+
+        if(name == null || date == null) {
+            findList = scheduleRepository.findAllScheduleLists();
+        }
+
+        if(name != null || date != null) {
+            findList = scheduleRepository.findScheduleListByNameWithDate(date, name);
+        }
+
+        if (name != null) {
+            findList = scheduleRepository.findScheduleListByName(name);
+        }
+
+        if (date != null) {
+            findList = scheduleRepository.findScheduleListByDate(date);
+        }
+
+        return findList;
     }
 }


### PR DESCRIPTION
이름과 날짜 파리미터를 모두 받았을때와 안 받았을 때 조회가 정상적으로 안 되던 문제 수정
데이터베이스에서 이름, 날짜, 이름&날짜, 전체로 조회하는 메서드를 나누어 받는 값에 따라 반환하도록 수정