### PR TITLE
Refactor: author data divide

### DIFF
--- a/src/main/java/dh/scheduler/controller/ScheduleController.java
+++ b/src/main/java/dh/scheduler/controller/ScheduleController.java
@@ -30,6 +30,7 @@ public class ScheduleController {
         return new ResponseEntity<>(scheduleService.saveSchedule(requestDto), HttpStatus.CREATED);
     }
 
+
     /**
      * 선택 일정 조회 API
      * @param id 선택한 id 식별자
@@ -55,5 +56,11 @@ public class ScheduleController {
             @RequestBody ScheduleRequestDto requestDto
             ) {
         return new ResponseEntity<>(scheduleService.updateSchedule(id, requestDto.getUserName(), requestDto.getContents(), requestDto.getPassword()), HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteSchedule(@PathVariable Long id) {
+        scheduleService.deleteSchedule(id);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/dh/scheduler/dto/ScheduleResponseDto.java
+++ b/src/main/java/dh/scheduler/dto/ScheduleResponseDto.java
@@ -1,5 +1,6 @@
 package dh.scheduler.dto;
 
+import dh.scheduler.entity.Author;
 import dh.scheduler.entity.Schedule;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,6 +12,7 @@ import java.time.LocalDateTime;
 public class ScheduleResponseDto {
 
     private Long id;
+    private Long author_id;
     private String userName;
     private String title;
     private String password;
@@ -18,13 +20,14 @@ public class ScheduleResponseDto {
     private LocalDateTime createDate;
     private LocalDateTime updateDate;
 
-    public ScheduleResponseDto(Schedule schedule) {
+    public ScheduleResponseDto(Schedule schedule, Author author) {
         this.id = schedule.getId();
-        this.userName = schedule.getUserName();
+        this.author_id = author.getId();
+        this.userName = author.getUserName();
         this.title = schedule.getTitle();
         this.password = schedule.getPassword();
         this.contents = schedule.getContents();
-        this.createDate = schedule.getCreateDate();
-        this.updateDate = schedule.getUpdateDate();
+        this.createDate = schedule.getCreatedAt();
+        this.updateDate = schedule.getUpdatedAt();
     }
 }

--- a/src/main/java/dh/scheduler/entity/Author.java
+++ b/src/main/java/dh/scheduler/entity/Author.java
@@ -1,0 +1,36 @@
+package dh.scheduler.entity;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class Author {
+    private Long id;
+    private String userName;
+    private String email;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public Author(String userName) {
+        this.userName = userName;
+        this.createdAt = setCreateDate();
+        this.updatedAt = createdAt;
+    }
+
+    public Author(Long id, String userName, LocalDateTime createAt, LocalDateTime updateAt) {
+        this.id = id;
+        this.userName = userName;
+        this.createdAt = createAt;
+        this.updatedAt = updateAt;
+    }
+
+    public LocalDateTime setCreateDate() {
+        LocalDateTime now = LocalDateTime.now();
+        return this.createdAt = now;
+    }
+
+
+}
+
+

--- a/src/main/java/dh/scheduler/entity/Schedule.java
+++ b/src/main/java/dh/scheduler/entity/Schedule.java
@@ -10,25 +10,25 @@ import java.time.LocalDateTime;
 public class Schedule {
 
     private Long id;
-    private String userName;
+    private Long authorId;
     private String title;
     private String password;
     private String contents;
-    private LocalDateTime createDate;
-    private LocalDateTime updateDate;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 
-    public Schedule(String userName, String title, String password, String contents) {
-        this.userName = userName;
+    public Schedule(Long authorId, String title, String password, String contents) {
+        this.authorId = authorId;
         this.title = title;
         this.password = password;
         this.contents = contents;
-        this.createDate = setCreateDate();
-        this.updateDate = createDate;
+        this.createdAt = setCreatedAt();
+        this.updatedAt = createdAt;
     }
 
-    public LocalDateTime setCreateDate() {
+    public LocalDateTime setCreatedAt() {
         LocalDateTime now = LocalDateTime.now();
-        return this.createDate = now;
+        return this.createdAt = now;
     }
 
 }

--- a/src/main/java/dh/scheduler/repository/JdbcTemplateScheduleRepository.java
+++ b/src/main/java/dh/scheduler/repository/JdbcTemplateScheduleRepository.java
@@ -1,6 +1,7 @@
 package dh.scheduler.repository;
 
 import dh.scheduler.dto.ScheduleResponseDto;
+import dh.scheduler.entity.Author;
 import dh.scheduler.entity.Schedule;
 import org.springframework.http.HttpStatus;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -29,29 +30,49 @@ public class JdbcTemplateScheduleRepository implements ScheduleRepository {
 
 
     @Override
-    public ScheduleResponseDto saveSchedule(Schedule schedule) {
+    public Schedule saveSchedule(Schedule schedule) {
 
         SimpleJdbcInsert jdbcInsert = new SimpleJdbcInsert(jdbcTemplate);
         jdbcInsert.withTableName("Schedule").usingGeneratedKeyColumns("id");
 
         Map<String, Object> parameters = new HashMap<>();
-        parameters.put("userName", schedule.getUserName());
+        parameters.put("authorId", schedule.getAuthorId());
         parameters.put("title", schedule.getTitle());
         parameters.put("password", schedule.getPassword());
         parameters.put("contents", schedule.getContents());
-        parameters.put("createDate", schedule.getCreateDate());
-        parameters.put("updateDate", schedule.getUpdateDate());
+        parameters.put("createdAt", schedule.getCreatedAt());
+        parameters.put("updatedAt", schedule.getUpdatedAt());
 
         Number key = jdbcInsert.executeAndReturnKey(new MapSqlParameterSource(parameters));
 
-        return new ScheduleResponseDto(
+        return new Schedule(
                 key.longValue(),
-                schedule.getUserName(),
+                schedule.getAuthorId(),
                 schedule.getTitle(),
                 schedule.getPassword(),
                 schedule.getContents(),
-                schedule.getCreateDate(),
-                schedule.getUpdateDate());
+                schedule.getCreatedAt(),
+                schedule.getUpdatedAt());
+    }
+
+    @Override
+    public Author saveAuthor(Author author) {
+
+        SimpleJdbcInsert jdbcInsert = new SimpleJdbcInsert(jdbcTemplate);
+        jdbcInsert.withTableName("author").usingGeneratedKeyColumns("id");
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("userName", author.getUserName());
+        parameters.put("createdAt", author.getCreatedAt());
+        parameters.put("updatedAt", author.getUpdatedAt());
+
+        Number key = jdbcInsert.executeAndReturnKey(new MapSqlParameterSource(parameters));
+
+        return new Author(
+                key.longValue(),
+                author.getUserName(),
+                author.getCreatedAt(),
+                author.getUpdatedAt());
     }
 
     @Override
@@ -62,28 +83,48 @@ public class JdbcTemplateScheduleRepository implements ScheduleRepository {
     }
 
     @Override
+    public Author findAuthorById(Long id) {
+        List<Author> result = jdbcTemplate.query("select a.* from author a join Schedule s on a.id=s.author_id where s.id = ? ", authorRowMapper(), id);
+
+        return result.stream().findAny().orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "id를 찾을 수 없습니다."));
+    }
+
+
+
+
+    @Override
     public List<ScheduleResponseDto> findScheduleListByDate(String date) {
-        return jdbcTemplate.query("select * from Schedule where date(update_date) = ?", scheduleRowMappers(), date);
+        return jdbcTemplate.query("select * from Schedule s join author a on s.author_id=a.id where date(s.updatedAt) = ?", scheduleRowMappers(), date);
     }
 
     @Override
     public List<ScheduleResponseDto> findScheduleListByName(String name) {
-        return jdbcTemplate.query("select * from Schedule where user_name = ?", scheduleRowMappers(), name);
+        return jdbcTemplate.query("select * from Schedule s join author a on s.author_id=a.id where a.user_name = ?", scheduleRowMappers(), name);
     }
 
     @Override
     public List<ScheduleResponseDto> findScheduleListByNameWithDate(String date, String name) {
-        return jdbcTemplate.query("select * from Schedule where user_name = ? and date(update_date) = ?", scheduleRowMappers(), name, date);
+        return jdbcTemplate.query("select * from Schedule s join author a on s.author_id=a.id where a.user_name = ? and date(s.updatedAt) = ? ", scheduleRowMappers(), name, date);
     }
 
     @Override
     public List<ScheduleResponseDto> findAllScheduleLists() {
-        return jdbcTemplate.query("select * from Schedule", scheduleRowMappers());
+        return jdbcTemplate.query("select * from Schedule s join author a on s.author_id = a.id ", scheduleRowMappers());
     }
 
     @Override
-    public int updateSchedule(Long id, String name, String contents, LocalDateTime now) {
-        return jdbcTemplate.update("update Schedule set user_name = ?, contents = ?, update_date = ? where id = ?", name, contents, now, id);
+    public int updateSchedule(Long id, String contents, LocalDateTime now) {
+        return jdbcTemplate.update("update Schedule set contents = ?, updatedAt = ? where id = ?", contents, now, id);
+    }
+
+    @Override
+    public int updateAuthor(Long id, String name) {
+        return jdbcTemplate.update("update author set user_name = ? where id = ?", name, id);
+    }
+
+    @Override
+    public int deleteSchedule(Long id) {
+        return jdbcTemplate.update("delete from Schedule where id = ?", id);
     }
 
 
@@ -93,16 +134,17 @@ public class JdbcTemplateScheduleRepository implements ScheduleRepository {
             public Schedule mapRow(ResultSet rs, int rowNum) throws SQLException {
                 return new Schedule(
                         rs.getLong("id"),
-                        rs.getString("user_name"),
+                        rs.getLong("author_id"),
                         rs.getString("title"),
                         rs.getString("password"),
                         rs.getString("contents"),
-                        rs.getTimestamp("create_date").toLocalDateTime(),
-                        rs.getTimestamp("update_date").toLocalDateTime()
+                        rs.getTimestamp("createdAt").toLocalDateTime(),
+                        rs.getTimestamp("updatedAt").toLocalDateTime()
                 );
             }
         };
     }
+    
 
     private RowMapper<ScheduleResponseDto> scheduleRowMappers() {
         return new RowMapper<ScheduleResponseDto>() {
@@ -110,14 +152,31 @@ public class JdbcTemplateScheduleRepository implements ScheduleRepository {
             public ScheduleResponseDto mapRow(ResultSet rs, int rowNum) throws SQLException {
                 return new ScheduleResponseDto(
                         rs.getLong("id"),
+                        rs.getLong("author_id"),
                         rs.getString("user_name"),
                         rs.getString("title"),
                         rs.getString("password"),
                         rs.getString("contents"),
-                        rs.getTimestamp("create_date").toLocalDateTime(),
-                        rs.getTimestamp("update_date").toLocalDateTime()
+                        rs.getTimestamp("createdAt").toLocalDateTime(),
+                        rs.getTimestamp("updatedAt").toLocalDateTime()
                 );
             }
         };
     }
+
+    private RowMapper<Author> authorRowMapper() {
+        return new RowMapper<Author>() {
+            @Override
+            public Author mapRow(ResultSet rs, int rowNum) throws SQLException {
+                return new Author(
+                        rs.getLong("id"),
+                        rs.getString("user_name"),
+                        rs.getTimestamp("createdAt").toLocalDateTime(),
+                        rs.getTimestamp("updatedAt").toLocalDateTime()
+                );
+            }
+        };
+    }
+    
+    
 }

--- a/src/main/java/dh/scheduler/repository/ScheduleRepository.java
+++ b/src/main/java/dh/scheduler/repository/ScheduleRepository.java
@@ -1,6 +1,7 @@
 package dh.scheduler.repository;
 
 import dh.scheduler.dto.ScheduleResponseDto;
+import dh.scheduler.entity.Author;
 import dh.scheduler.entity.Schedule;
 
 import java.time.LocalDateTime;
@@ -8,9 +9,13 @@ import java.util.List;
 
 public interface ScheduleRepository {
 
-    ScheduleResponseDto saveSchedule(Schedule schedule);
+    Schedule saveSchedule(Schedule schedule);
+
+    Author saveAuthor(Author author);
 
     Schedule findScheduleById(Long id);
+
+    Author findAuthorById(Long id);
 
     List<ScheduleResponseDto> findScheduleListByDate(String date);
 
@@ -20,6 +25,10 @@ public interface ScheduleRepository {
 
     List<ScheduleResponseDto> findAllScheduleLists();
 
-    int updateSchedule(Long id, String name, String contents, LocalDateTime now);
+    int updateSchedule(Long id, String contents, LocalDateTime now);
+
+    int updateAuthor(Long id, String name);
+
+    int deleteSchedule(Long id);
 
 }

--- a/src/main/java/dh/scheduler/service/ScheduleService.java
+++ b/src/main/java/dh/scheduler/service/ScheduleService.java
@@ -14,4 +14,6 @@ public interface ScheduleService {
     List<ScheduleResponseDto> findListSchedules(String date, String name);
 
     ScheduleResponseDto updateSchedule(Long id, String name, String contents, String password);
+
+    void deleteSchedule(Long id);
 }

--- a/src/main/java/dh/scheduler/service/ScheduleServiceImpl.java
+++ b/src/main/java/dh/scheduler/service/ScheduleServiceImpl.java
@@ -2,15 +2,14 @@ package dh.scheduler.service;
 
 import dh.scheduler.dto.ScheduleRequestDto;
 import dh.scheduler.dto.ScheduleResponseDto;
+import dh.scheduler.entity.Author;
 import dh.scheduler.entity.Schedule;
 import dh.scheduler.repository.ScheduleRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -26,22 +25,37 @@ public class ScheduleServiceImpl implements ScheduleService{
     @Override
     public ScheduleResponseDto saveSchedule(ScheduleRequestDto requestDto) {
 
+        Author author = new Author(requestDto.getUserName());
+
+        author = scheduleRepository.saveAuthor(author);
+
         Schedule schedule = new Schedule(
-                requestDto.getUserName(),
+                author.getId(),
                 requestDto.getTitle(),
                 requestDto.getPassword(),
                 requestDto.getContents()
-                );
+        );
 
-        return scheduleRepository.saveSchedule(schedule);
+        schedule = scheduleRepository.saveSchedule(schedule);
+
+        return new ScheduleResponseDto(
+                schedule.getId(),
+                author.getId(),
+                author.getUserName(),
+                schedule.getTitle(),
+                schedule.getPassword(),
+                schedule.getContents(),
+                schedule.getCreatedAt(),
+                schedule.getUpdatedAt());
     }
 
     @Override
     public ScheduleResponseDto findScheduleById(Long id) {
 
         Schedule schedule = scheduleRepository.findScheduleById(id);
+        Author author = scheduleRepository.findAuthorById(id);
 
-        return new ScheduleResponseDto(schedule);
+        return new ScheduleResponseDto(schedule, author);
     }
 
     @Override
@@ -76,10 +90,24 @@ public class ScheduleServiceImpl implements ScheduleService{
         }
 
         LocalDateTime now = LocalDateTime.now();
-        scheduleRepository.updateSchedule(id, name, contents, now);
+        scheduleRepository.updateSchedule(id, contents, now);
         Schedule schedule = scheduleRepository.findScheduleById(id);
 
-        return new ScheduleResponseDto(schedule);
+        scheduleRepository.updateAuthor(schedule.getAuthorId(), name);
+        Author author = scheduleRepository.findAuthorById(id);
+
+        return new ScheduleResponseDto(schedule, author);
+
+    }
+
+    @Override
+    public void deleteSchedule(Long id) {
+
+        int deleteRow = scheduleRepository.deleteSchedule(id);
+
+        if (deleteRow == 0) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "id를 찾을 수 없습니다.");
+        }
     }
 
 


### PR DESCRIPTION
작성자명 테이블로 분리하여 관리
- 기존 일정 테이블 작성자명 필드 제거
- 일정을 생성할 때 작성자 새로 생성
- 기존 조회, 수정 메서드 author 테이블에서 데이터 가져오도록 리팩토링